### PR TITLE
added RUM prefix to tracking ID to be included in JS file request

### DIFF
--- a/src/view/frontend/templates/script/rumvision.phtml
+++ b/src/view/frontend/templates/script/rumvision.phtml
@@ -26,5 +26,5 @@ if (! $viewModel->shouldIncludeScript()) {
         var head = si.querySelector('head'), js = si.createElement('script');
         js.src = 'https://d5yoctgpv4cpx.cloudfront.net/'+rum+'/v4-'+vi.location.hostname+'.js';
         head.appendChild(js);
-    })( '<?= $escaper->escapeJs($viewModel->getTrackingId()) ?>', window, document, '<?= $escaper->escapeJs($viewModel->getHostName()) ?>' );
+    })( 'RUM-<?= $escaper->escapeJs($viewModel->getTrackingId()) ?>', window, document, '<?= $escaper->escapeJs($viewModel->getHostName()) ?>' );
 </script>


### PR DESCRIPTION
When URLs or tracking configuration has changed from within RUMvision portal, RUMvision will actively invalidate CDN caches of JS files using the `RUM-` prefix.
Any JS files loaded without the `RUM-` prefix will see changes reflected with a longer delay (equal to the CDN cache duration = 24 hours at time of writing).

Not using `RUM-` prefix could lead to not seeing newly added URLs being tracked right away. 