### PR TITLE
Add RUM prefix to tracking id

### DIFF
--- a/src/ViewModel/Rumvision.php
+++ b/src/ViewModel/Rumvision.php
@@ -27,8 +27,8 @@ class Rumvision implements ArgumentInterface
 
     public function getTrackingId() :string
     {
-        return $this->configuration
-                ->getTrackingId();
+        $trackingId = $this->configuration->getTrackingId();
+        return str_starts_with($trackingId, 'RUM-') ? $trackingId : sprintf('RUM-%s', $trackingId);
     }
 
     public function getHostName() :string

--- a/src/view/frontend/templates/script/rumvision.phtml
+++ b/src/view/frontend/templates/script/rumvision.phtml
@@ -21,10 +21,10 @@ if (! $viewModel->shouldIncludeScript()) {
         if ( s.urls && s.regex && ( s.page = eval('('+s.regex+')')( s.urls, vi.location.pathname ) ) && !s.page.type ) {
             return sessionStorage.setItem('rumv', JSON.stringify( s ) );
         }
-        
+
         vi.rumv.storage = s;
         var head = si.querySelector('head'), js = si.createElement('script');
         js.src = 'https://d5yoctgpv4cpx.cloudfront.net/'+rum+'/v4-'+vi.location.hostname+'.js';
         head.appendChild(js);
-    })( 'RUM-<?= $escaper->escapeJs($viewModel->getTrackingId()) ?>', window, document, '<?= $escaper->escapeJs($viewModel->getHostName()) ?>' );
+    })( '<?= $escaper->escapeJs($viewModel->getTrackingId()) ?>', window, document, '<?= $escaper->escapeJs($viewModel->getHostName()) ?>' );
 </script>


### PR DESCRIPTION
We found out that some projects didn't have the `RUM` prefix, which actually does work, so it's easily overlooked.

According to Rumvision the downside of omitting the `RUM` prefix that is that you can get old cached Rumvision JS (because of Cloudfront cache duration).