### PR TITLE
Declare PHP 8.3/8.4/8.5 support in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": "^8.0|^8.1|^8.2",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "magento/framework": "*",
         "magento/module-store": "*"
     },


### PR DESCRIPTION
Statically verified on PHP 8.5.6: php -l, PHPCompatibility (testVersion 8.0-8.5) and PHPStan level 6 against magento/framework 103.0.9 (2.4.9) all pass with zero findings.