### PR TITLE
Add client-based sampling rates, add bot agent filtering

### DIFF
--- a/src/Api/ConfigurationInterface.php
+++ b/src/Api/ConfigurationInterface.php
@@ -4,10 +4,11 @@ namespace Elgentos\Rumvision\Api;
 
 interface ConfigurationInterface
 {
-    public const CONFIG_RUMVISION_ENABLED       = 'elgentos_rumvision/general/enabled',
-                 CONFIG_RUMVISION_TRACKING_ID   = 'elgentos_rumvision/general/tracking_id',
-                 CONFIG_RUMVISION_HOST_NAME     = 'elgentos_rumvision/general/hostname',
-                 CONFIG_RUMVISION_SAMPLING_RATE = 'elgentos_rumvision/general/sampling_rate';
+    public const CONFIG_RUMVISION_ENABLED            = 'elgentos_rumvision/general/enabled',
+                 CONFIG_RUMVISION_TRACKING_ID       = 'elgentos_rumvision/general/tracking_id',
+                 CONFIG_RUMVISION_HOST_NAME         = 'elgentos_rumvision/general/hostname',
+                 CONFIG_RUMVISION_SAMPLING_RATE     = 'elgentos_rumvision/general/sampling_rate',
+                 CONFIG_RUMVISION_EXCLUDED_BOT_PATTERNS = 'elgentos_rumvision/general/excluded_bot_patterns';
 
     public function isEnabled(?int $storeId = null): bool;
 
@@ -16,5 +17,7 @@ interface ConfigurationInterface
     public function getHostName(?int $storeId = null) :string;
 
     public function getSamplingRate(?int $storeId = null) :int;
+
+    public function getExcludedBotPatterns(?int $storeId = null) :string;
 
 }

--- a/src/Api/ConfigurationInterface.php
+++ b/src/Api/ConfigurationInterface.php
@@ -6,12 +6,15 @@ interface ConfigurationInterface
 {
     public const CONFIG_RUMVISION_ENABLED       = 'elgentos_rumvision/general/enabled',
                  CONFIG_RUMVISION_TRACKING_ID   = 'elgentos_rumvision/general/tracking_id',
-                 CONFIG_RUMVISION_HOST_NAME     = 'elgentos_rumvision/general/hostname';
+                 CONFIG_RUMVISION_HOST_NAME     = 'elgentos_rumvision/general/hostname',
+                 CONFIG_RUMVISION_SAMPLING_RATE = 'elgentos_rumvision/general/sampling_rate';
 
     public function isEnabled(?int $storeId = null): bool;
 
     public function getTrackingId(?int $storeId = null) :string;
 
     public function getHostName(?int $storeId = null) :string;
+
+    public function getSamplingRate(?int $storeId = null) :int;
 
 }

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -64,6 +64,15 @@ class Config implements ConfigurationInterface
         return ($value > 0 && $value <= 100) ? $value : 100;
     }
 
+    public function getExcludedBotPatterns(?int $storeId = null): string
+    {
+        return (string)$this->config->getValue(
+            self::CONFIG_RUMVISION_EXCLUDED_BOT_PATTERNS,
+            ScopeInterface::SCOPE_STORE,
+            $this->getStoreId($storeId)
+        );
+    }
+
     public function getStoreId(?int $storeId = null) :int
     {
         return (int)$this->storeManager

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -53,6 +53,17 @@ class Config implements ConfigurationInterface
         );
     }
 
+    public function getSamplingRate(?int $storeId = null): int
+    {
+        $value = (int)$this->config->getValue(
+            self::CONFIG_RUMVISION_SAMPLING_RATE,
+            ScopeInterface::SCOPE_STORE,
+            $this->getStoreId($storeId)
+        );
+
+        return ($value > 0 && $value <= 100) ? $value : 100;
+    }
+
     public function getStoreId(?int $storeId = null) :int
     {
         return (int)$this->storeManager

--- a/src/ViewModel/Rumvision.php
+++ b/src/ViewModel/Rumvision.php
@@ -36,4 +36,9 @@ class Rumvision implements ArgumentInterface
         return $this->configuration
                 ->getHostName();
     }
+
+    public function getSamplingRate() :int
+    {
+        return $this->configuration->getSamplingRate();
+    }
 }

--- a/src/ViewModel/Rumvision.php
+++ b/src/ViewModel/Rumvision.php
@@ -41,4 +41,15 @@ class Rumvision implements ArgumentInterface
     {
         return $this->configuration->getSamplingRate();
     }
+
+    public function getExcludedBotPatterns() :array
+    {
+        $patterns = $this->configuration->getExcludedBotPatterns();
+
+        if (empty($patterns)) {
+            return [];
+        }
+
+        return array_filter(array_map('trim', explode("\n", $patterns)));
+    }
 }

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -44,6 +44,14 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
+                <field id="excluded_bot_patterns" translate="label tooltip comment" type="textarea" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Excluded Bot Patterns</label>
+                    <tooltip>User-Agent patterns to exclude from RUMvision tracking. Bots matching these patterns will be skipped.</tooltip>
+                    <comment>One pattern per line (case-insensitive match against User-Agent). Leave empty to disable bot filtering.</comment>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
             </group>
         </section>
     </system>

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -34,6 +34,16 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
+
+                <field id="sampling_rate" translate="label tooltip comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Sampling Rate (%)</label>
+                    <tooltip>Percentage of sessions to track. 100 = track all sessions (default).</tooltip>
+                    <comment>Enter a value between 1 and 100.</comment>
+                    <validate>required-entry validate-digits validate-digits-range digits-range-1-100</validate>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
             </group>
         </section>
     </system>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -8,6 +8,22 @@
                 <trackingId />
                 <hostname />
                 <sampling_rate>100</sampling_rate>
+                <excluded_bot_patterns>bot
+crawl
+spider
+slurp
+baidu
+yandex
+bing
+google
+duckduck
+semrush
+ahrefs
+lighthouse
+pagespeed
+gtmetrix
+facebookexternalhit
+meta-externalagent</excluded_bot_patterns>
             </general>
         </elgentos_rumvision>
     </default>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -7,6 +7,7 @@
                 <enabled />
                 <trackingId />
                 <hostname />
+                <sampling_rate>100</sampling_rate>
             </general>
         </elgentos_rumvision>
     </default>

--- a/src/view/frontend/layout/default.xml
+++ b/src/view/frontend/layout/default.xml
@@ -2,12 +2,19 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
 
-        <block name="before.body.end.rumvision" template="Elgentos_Rumvision::script/rumvision.phtml">
+        <block name="before.body.end.rumvision.sampling" template="Elgentos_Rumvision::script/sampling.phtml" before="before.body.end.rumvision">
             <arguments>
                 <argument name="rumvision_view_model" xsi:type="object">\Elgentos\Rumvision\ViewModel\Rumvision</argument>
             </arguments>
         </block>
 
+        <block name="before.body.end.rumvision" template="Elgentos_Rumvision::script/rumvision.phtml" after="before.body.end.rumvision.sampling">
+            <arguments>
+                <argument name="rumvision_view_model" xsi:type="object">\Elgentos\Rumvision\ViewModel\Rumvision</argument>
+            </arguments>
+        </block>
+
+        <move element="before.body.end.rumvision.sampling" destination="before.body.end" before="before.body.end.rumvision" />
         <move element="before.body.end.rumvision" destination="before.body.end" />
     </body>
 </page>

--- a/src/view/frontend/templates/script/rumvision.phtml
+++ b/src/view/frontend/templates/script/rumvision.phtml
@@ -12,19 +12,39 @@ $viewModel = $block->getData('rumvision_view_model');
 if (! $viewModel->shouldIncludeScript()) {
     return;
 }
+
+$samplingRate = (int)$viewModel->getSamplingRate();
 ?>
 
 <script>
-    window.rumv = window.rumv || function() { (window.rumv.q = window.rumv.q || []).push(arguments) };
-    (function(rum, vi,si,on) {
-        var s = JSON.parse( sessionStorage.getItem('rumv') || '{"pageviews":0}' ); s.pageviews++;
-        if ( s.urls && s.regex && ( s.page = eval('('+s.regex+')')( s.urls, vi.location.pathname ) ) && !s.page.type ) {
-            return sessionStorage.setItem('rumv', JSON.stringify( s ) );
-        }
+    (function() {
+        if (!isSessionSampled(<?= $samplingRate ?>)) return;
 
-        vi.rumv.storage = s;
-        var head = si.querySelector('head'), js = si.createElement('script');
-        js.src = 'https://d5yoctgpv4cpx.cloudfront.net/'+rum+'/v4-'+vi.location.hostname+'.js';
-        head.appendChild(js);
-    })( '<?= $escaper->escapeJs($viewModel->getTrackingId()) ?>', window, document, '<?= $escaper->escapeJs($viewModel->getHostName()) ?>' );
+        window.rumv = window.rumv || function() { (window.rumv.q = window.rumv.q || []).push(arguments) };
+        (function(rum, vi,si,on) {
+            var s = JSON.parse( sessionStorage.getItem('rumv') || '{"pageviews":0}' ); s.pageviews++;
+            if ( s.urls && s.regex && ( s.page = eval('('+s.regex+')')( s.urls, vi.location.pathname ) ) && !s.page.type ) {
+                return sessionStorage.setItem('rumv', JSON.stringify( s ) );
+            }
+
+            vi.rumv.storage = s;
+            var head = si.querySelector('head'), js = si.createElement('script');
+            js.src = 'https://d5yoctgpv4cpx.cloudfront.net/'+rum+'/v4-'+vi.location.hostname+'.js';
+            head.appendChild(js);
+        })( '<?= $escaper->escapeJs($viewModel->getTrackingId()) ?>', window, document, '<?= $escaper->escapeJs($viewModel->getHostName()) ?>' );
+
+        function isSessionSampled(rate) {
+            if (rate >= 100) return true;
+            try {
+                var sampled = sessionStorage.getItem('rumvision_sampled');
+                if (sampled === null) {
+                    sampled = (Math.random() * 100 < rate) ? '1' : '0';
+                    sessionStorage.setItem('rumvision_sampled', sampled);
+                }
+                return sampled === '1';
+            } catch (e) {
+                return true;
+            }
+        }
+    })();
 </script>

--- a/src/view/frontend/templates/script/rumvision.phtml
+++ b/src/view/frontend/templates/script/rumvision.phtml
@@ -12,39 +12,21 @@ $viewModel = $block->getData('rumvision_view_model');
 if (! $viewModel->shouldIncludeScript()) {
     return;
 }
-
-$samplingRate = (int)$viewModel->getSamplingRate();
 ?>
 
 <script>
-    (function() {
-        if (!isSessionSampled(<?= $samplingRate ?>)) return;
-
-        window.rumv = window.rumv || function() { (window.rumv.q = window.rumv.q || []).push(arguments) };
-        (function(rum, vi,si,on) {
-            var s = JSON.parse( sessionStorage.getItem('rumv') || '{"pageviews":0}' ); s.pageviews++;
-            if ( s.urls && s.regex && ( s.page = eval('('+s.regex+')')( s.urls, vi.location.pathname ) ) && !s.page.type ) {
-                return sessionStorage.setItem('rumv', JSON.stringify( s ) );
-            }
-
-            vi.rumv.storage = s;
-            var head = si.querySelector('head'), js = si.createElement('script');
-            js.src = 'https://d5yoctgpv4cpx.cloudfront.net/'+rum+'/v4-'+vi.location.hostname+'.js';
-            head.appendChild(js);
-        })( '<?= $escaper->escapeJs($viewModel->getTrackingId()) ?>', window, document, '<?= $escaper->escapeJs($viewModel->getHostName()) ?>' );
-
-        function isSessionSampled(rate) {
-            if (rate >= 100) return true;
-            try {
-                var sampled = sessionStorage.getItem('rumvision_sampled');
-                if (sampled === null) {
-                    sampled = (Math.random() * 100 < rate) ? '1' : '0';
-                    sessionStorage.setItem('rumvision_sampled', sampled);
-                }
-                return sampled === '1';
-            } catch (e) {
-                return true;
-            }
+    if (!window.__rumvisionSkip) {
+    window.rumv = window.rumv || function() { (window.rumv.q = window.rumv.q || []).push(arguments) };
+    (function(rum, vi,si,on) {
+        var s = JSON.parse( sessionStorage.getItem('rumv') || '{"pageviews":0}' ); s.pageviews++;
+        if ( s.urls && s.regex && ( s.page = eval('('+s.regex+')')( s.urls, vi.location.pathname ) ) && !s.page.type ) {
+            return sessionStorage.setItem('rumv', JSON.stringify( s ) );
         }
-    })();
+
+        vi.rumv.storage = s;
+        var head = si.querySelector('head'), js = si.createElement('script');
+        js.src = 'https://d5yoctgpv4cpx.cloudfront.net/'+rum+'/v4-'+vi.location.hostname+'.js';
+        head.appendChild(js);
+    })( '<?= $escaper->escapeJs($viewModel->getTrackingId()) ?>', window, document, '<?= $escaper->escapeJs($viewModel->getHostName()) ?>' );
+    }
 </script>

--- a/src/view/frontend/templates/script/sampling.phtml
+++ b/src/view/frontend/templates/script/sampling.phtml
@@ -15,11 +15,20 @@ $samplingRate = (int)$viewModel->getSamplingRate();
 if ($samplingRate >= 100) {
     return;
 }
+
+$excludedBotPatterns = $viewModel->getExcludedBotPatterns();
 ?>
 
 <script>
     (function() {
         try {
+            <?php if (!empty($excludedBotPatterns)): ?>
+            if (navigator.webdriver || new RegExp(<?= json_encode(implode('|', $excludedBotPatterns)) ?>, 'i').test(navigator.userAgent)) {
+                window.__rumvisionSkip = true;
+                return;
+            }
+            <?php endif; ?>
+
             let sampled = sessionStorage.getItem('rumvision_sampled');
             if (sampled === null) {
                 sampled = (Math.random() * 100 < <?= $samplingRate ?>) ? '1' : '0';

--- a/src/view/frontend/templates/script/sampling.phtml
+++ b/src/view/frontend/templates/script/sampling.phtml
@@ -1,0 +1,33 @@
+<?php
+
+/** @var Template $block */
+
+use Elgentos\Rumvision\ViewModel\Rumvision;
+use Magento\Framework\View\Element\Template;
+
+/** @var Rumvision $viewModel */
+$viewModel = $block->getData('rumvision_view_model');
+if (! $viewModel->shouldIncludeScript()) {
+    return;
+}
+
+$samplingRate = (int)$viewModel->getSamplingRate();
+if ($samplingRate >= 100) {
+    return;
+}
+?>
+
+<script>
+    (function() {
+        try {
+            let sampled = sessionStorage.getItem('rumvision_sampled');
+            if (sampled === null) {
+                sampled = (Math.random() * 100 < <?= $samplingRate ?>) ? '1' : '0';
+                sessionStorage.setItem('rumvision_sampled', sampled);
+            }
+            window.__rumvisionSkip = sampled === '0';
+        } catch (e) {
+            window.__rumvisionSkip = false;
+        }
+    })();
+</script>


### PR DESCRIPTION
## Add client-based sampling rates
Adds a possibility to configure client-based sampling rating of any scale from Magento admin panel based on probabilities

## Add bot filtering
Makes it possible to manage excluded user agents to not track bots traffic noise